### PR TITLE
Remove the underline from the navbar's links (in mobile view)

### DIFF
--- a/style.css
+++ b/style.css
@@ -521,8 +521,8 @@ footer ul li {
   .nav-links a {
     color: white;
     font-size: var(--header3);
-    text-decoration: underline;
   }
+
   .nav-links {
     background: #247b7b;
     width: 100%;


### PR DESCRIPTION
In "style.css", under the media query, I removed `text-decoration: underline;` from `.nav-links a `in order to remove the underline from the navbar's links (in mobile view).